### PR TITLE
Displaying name of created action

### DIFF
--- a/config/deploy-operations.php
+++ b/config/deploy-operations.php
@@ -123,4 +123,27 @@ return [
 
         'name' => env('DEPLOY_OPERATIONS_QUEUE_NAME'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Show
+    |--------------------------------------------------------------------------
+    |
+    | This option determines the display settings for various information messages.
+    |
+    */
+
+    'show' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Full Path
+        |--------------------------------------------------------------------------
+        |
+        | This parameter determines how exactly the link to the created file should
+        | be displayed - the full path to the file or a relative one.
+        |
+        */
+
+        'full_path' => env('DEPLOY_OPERATIONS_SHOW_FULL_PATH', false),
+    ],
 ];

--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -51,6 +51,11 @@ class Config
         return base_path();
     }
 
+    public function showFullPath(): bool
+    {
+        return (bool) $this->config->get('deploy-operations.show.full_path');
+    }
+
     protected function directory(): string
     {
         return $this->config->get('deploy-operations.path', base_path('operations'));

--- a/src/Processors/Make.php
+++ b/src/Processors/Make.php
@@ -22,17 +22,19 @@ class Make extends Processor
 
     public function handle(): void
     {
-        $this->notification->task($this->message(), fn () => $this->create());
+        $fullPath = $this->getFullPath();
+
+        $this->notification->task($this->message($fullPath), fn () => $this->create($fullPath));
     }
 
-    protected function message(): string
+    protected function message(string $path): string
     {
-        return 'Operation [' . $this->displayName($this->getFullPath()) . '] created successfully';
+        return 'Operation [' . $this->displayName($path) . '] created successfully';
     }
 
-    protected function create(): void
+    protected function create(string $path): void
     {
-        File::copy($this->stubPath(), $this->getFullPath());
+        File::copy($this->stubPath(), $path);
     }
 
     protected function displayName(string $path): string
@@ -46,9 +48,9 @@ class Make extends Processor
 
     protected function getName(): string
     {
-        $branch = $this->getBranchName();
-
-        return $this->getFilename($branch);
+        return $this->getFilename(
+            $this->getBranchName()
+        );
     }
 
     protected function getPath(): string

--- a/src/Processors/Make.php
+++ b/src/Processors/Make.php
@@ -21,15 +21,9 @@ class Make extends Processor
 
     public function handle(): void
     {
-        $this->notification->task('Creating an operation', fn () => $this->run());
-    }
+        $pathWithName = $this->getPath().$this->getName();
 
-    protected function run(): void
-    {
-        $name = $this->getName();
-        $path = $this->getPath();
-
-        $this->create($path . '/' . $name);
+        $this->notification->task('Creating an operation ['.$pathWithName.']', fn () => $this->create($pathWithName));
     }
 
     protected function create(string $path): void
@@ -59,6 +53,7 @@ class Make extends Processor
             ->prepend($this->getTime())
             ->finish('.php')
             ->prepend($directory . '/')
+            ->ltrim('./')
             ->toString();
     }
 


### PR DESCRIPTION
I changed the notification text to Laravel-style in the `make:something` commands. This speeds up the file creation process because you can copy the filename with the path directly from the terminal instead of searching by typing the name a second time or in the git toolbar.

Now the output looks like this:
![image](https://github.com/user-attachments/assets/80dc614d-8ec2-4584-a310-3be4eb7ce0ac)


Additionally, I fixed the generating path with the name, because at this moment it looks like `operations//./action_name.php`:
![image](https://github.com/user-attachments/assets/a45463d5-8a39-4330-b166-fdeeaf059240)
